### PR TITLE
Custom Marks without MarkDefs

### DIFF
--- a/lib/ex_sanity/portable_text/serializers.ex
+++ b/lib/ex_sanity/portable_text/serializers.ex
@@ -75,8 +75,10 @@ defmodule ExSanity.PortableText.Serializers do
     if Enum.member?(@default_marks, mark) do
       content_tag(Utils.mark_to_atom(mark), content)
     else
-      mark_def = Enum.find(mark_defs, fn mark_def -> mark_def["_key"] == mark end)
-      render_custom_mark(serializers, mark_def, content)
+      case Enum.find(mark_defs, fn mark_def -> mark_def["_key"] == mark end) do
+        nil -> render_custom_mark(serializers, mark, content)
+        mark_def -> render_custom_mark(serializers, mark_def, content)
+      end
     end
   end
 
@@ -88,6 +90,17 @@ defmodule ExSanity.PortableText.Serializers do
       mark_serializers[type_as_atom].(serializers, mark_def, content)
     else
       raise "a custom serializer for type: #{type} could not be found"
+    end
+  end
+
+  def render_custom_mark(serializers, mark, content) do
+    mark_serializers = serializers[:marks]
+    type_as_atom = String.to_atom(mark)
+
+    if Map.has_key?(mark_serializers, type_as_atom) do
+      mark_serializers[type_as_atom].(serializers, mark, content)
+    else
+      raise "a custom serializer for mark: #{mark} could not be found"
     end
   end
 end


### PR DESCRIPTION
Encountered this case:
```
[
  %{
    "_key" => "f95162d6c8e5",
    "_type" => "block",
    "children" => [
       %{
          "_key" => "143fdf28782a",
          "_type" => "span",
          "marks" => [],
          "text" => "FAFSA applications open on "
        },
        %{
          "_key" => "2f97e7908493",
          "_type" => "span",
          "marks" => ["highlight"],
          "text" => "October 11"
        },
        %{
          "_key" => "0a473edc23a9",
          "_type" => "span",
          "marks" => [],
          "text" => ". Get started now with this guide."
        }
      ],
      "markDefs" => [],
      "style" => "normal"
  }
]
```
There is a custom mark (`highlight`) that has no corresponding markDefs.

The current implementation doesn't allow for custom marks that don't have corresponding markDefs (since we match on a success case where a markDef is found in the `mark_def = Enum.find(mark_defs, fn mark_def -> mark_def["_key"] == mark end)` line).

Am I thinking about this correctly? @sepowitz 