### PR TITLE
Handle timeout and avoid CaseClauseError

### DIFF
--- a/lib/ex_sanity/client.ex
+++ b/lib/ex_sanity/client.ex
@@ -54,6 +54,10 @@ defmodule ExSanity.Client do
       {:ok, %HTTPoison.Response{body: %{"message" => message}, status_code: status}} ->
         {:error, %{code: status, message: message}}
 
+      {:ok,
+       %HTTPoison.Response{body: %{"error" => %{"type" => "timeoutError"}}, status_code: 524}} ->
+        {:error, :timeout}
+
       {:error, reason} ->
         {:error, reason}
     end


### PR DESCRIPTION
Currently a timeout communicating with Sanity causes a `CaseClauseError` because the case doesn't have an accurate pattern to capture it. This adds it, returning `{:error, :timeout}`.